### PR TITLE
Don't raise an exception on weekends

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,15 +1,15 @@
 # frozen_string_literal:true
 
-desc 'This task is called by the Heroku scheduler add-on'
+desc 'This tasks are called by the Heroku scheduler add-on'
 
 namespace :daily_menus do
   task gather: :environment do
-    abort("Leave me alone. It's the weekend!") if Date.today.on_weekend?
+    next if Date.today.on_weekend?
     Restaurant.gather_daily_menus
   end
 
   task broadcast: :environment do
-    abort('No broadcasts on the weekend!') if Date.today.on_weekend?
+    next if Date.today.on_weekend?
     Restaurant::DailyMenu.broadcast
   end
 end


### PR DESCRIPTION
Using `abort` will raise an `SystemExit` exception.

We should avoid exceptions for desired behaviours. 